### PR TITLE
Update js-yaml resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "typescript": "^5.9.3"
   },
   "resolutions": {
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^5.2.1",
     "nanoid": "^3.3.8"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2584,10 +2584,10 @@ jiti@^1.19.1:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
-  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
+js-yaml@^4.3.0, js-yaml@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-5.2.1.tgz#bb3f2e87295ebfe6ef0a75e17c62834daeff9ce2"
+  integrity sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
## Summary
- Update the Yarn resolution for js-yaml from the v4 legacy line to 5.2.1.
- Refresh yarn.lock so ESLint's transitive js-yaml install resolves to 5.2.1.

## Security
Follows up on the Aikido js-yaml dependency finding after PR #39 added lockfile coverage and prior site fixes.

## Verification
- yarn list --pattern js-yaml --depth=0 shows js-yaml@5.2.1
- npm run lint
- npm run build